### PR TITLE
posts.php security fix and baseline shortlink redirect

### DIFF
--- a/src/php/blog.php
+++ b/src/php/blog.php
@@ -3,6 +3,7 @@
 //  1 or "blog" = displays all posts, takes max posts as auxinfo
 //  2 = or "folder" =  displays folder
 //  3 = or "post" = Displays a specific post.
+//  4 = or "short" = (Currently) Displays a specfic post
 
 
 function nodb_blog($content, $auxinfo)

--- a/src/php/funcs/unshorten.php
+++ b/src/php/funcs/unshorten.php
@@ -23,8 +23,8 @@ function unshorten($content)
         $hash = substr($hash, 0, 6);
 
         if ($hash == $content)
-        {
-            return trim($f, "/");
+        { // This file matches the short hash we were looking for - here we enforce a redirect
+            header("Location: /blog.php?p=".$f); // Assuming no output before this point, will send a HTTP Redirect
         }
      }
     echo "Invalid link";

--- a/src/php/posts.php
+++ b/src/php/posts.php
@@ -1,11 +1,13 @@
 <?php
 
-    $dir = $_GET["dir"]; //get directory
+    $dir = str_replace("/","",$_GET["dir"]); // Get sub-directory and (basic) prevent escapes.
     if ($dir == "")
     {
-        $dir = "posts";   //If the folder wasnt specified, then use the posts folder
+        $dir = $post_dir;   //If the folder wasnt specified, then use the default posts folder (from config.php)
+    } else {
+        $dir = $post_dir."/".$dir; // If a sub was specified, append after the default folder
     }
-    $post = $_GET["post"];
+    $post = str_replace("/","",$_GET["post"]); // Hacky way to fix major security hole
     
     if ($post == "")
     {


### PR DESCRIPTION
By no means perfect, a basic no-directory-escalation check put in place on posts.php, and a basic header() location statement added for shortlinks. Entirely untested.
(Also added the description for behaviour 4 as it was missing but defined!)
